### PR TITLE
Create an option to remove all players except yourself

### DIFF
--- a/src/com/company/assembleegameclient/map/Map.as
+++ b/src/com/company/assembleegameclient/map/Map.as
@@ -408,7 +408,7 @@ public class Map extends AbstractMap {
                             this.visibleUnder_.push(_local_13);
                         }
                     }
-                    else {
+                    else if (!_local_13.props_.isPlayer_ || _local_13.objectId_ == this.player_.objectId_) {
                         this.visible_.push(_local_13);
                     }
                 }


### PR DESCRIPTION
Problem: In lost hall with all people you can't see enemies and loots. Also extra players create extra lag.
Answer: Remove all player except yourself but left the minimap unchanged as landmark.