### PR TITLE
Properly update enemy health when damaged

### DIFF
--- a/src/com/company/assembleegameclient/objects/GameObject.as
+++ b/src/com/company/assembleegameclient/objects/GameObject.as
@@ -740,6 +740,9 @@ public class GameObject extends BasicObject {
         var _local_14:Vector.<uint>;
         var _local_15:Boolean;
         var _local_6:Boolean;
+	
+	this.hp_ -= _arg_2;
+	
         if (_arg_4) {
             this.dead_ = true;
         }


### PR DESCRIPTION
The client doesn't update health so you can't completely kill things with spell bombs. This fixes that!